### PR TITLE
chore: remove esnext option to enable it for jscs 3.0

### DIFF
--- a/jscs.json
+++ b/jscs.json
@@ -1,5 +1,4 @@
 {
   "preset": "google",
-  "esnext": true,
   "maximumLineLength": null
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jscs-preset-mrjoelkemp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "My JSCS config",
   "main": "jscs.json",
   "scripts": {


### PR DESCRIPTION
with jscs 3.0 - it results in the above mentioned error.
```console
Config values to remove in 3.0:
The `esnext` option is enabled by default.
```
 Removing the same to fix it. 